### PR TITLE
Update parserErrorPattern regexp

### DIFF
--- a/lib/language-ledger.coffee
+++ b/lib/language-ledger.coffee
@@ -71,7 +71,7 @@ module.exports =
     buffer = editor.getBuffer()
     bufferSavedSubscription = buffer.onDidSave (file) =>
       failDetail = (message) ->
-        parserErrorPattern = /While parsing file +\"(.+)\", line ([\d]+): [\n\r]+([\s\S]+)$/m
+        parserErrorPattern = /While parsing file +\"(.+)\", line ([\d]+): ?[\n\r]+([\s\S]+)$/m
         hasParserError = parserErrorPattern.test message
 
         if hasParserError


### PR DESCRIPTION
It wasn't matching a simple invalid date error and the notification was lacking details.

ledger version 3.1.0-20141005

Before:
![1453301954](https://cloud.githubusercontent.com/assets/726447/12452489/680a8300-bf6d-11e5-991c-d347a709b93a.png)

After
![1453301918](https://cloud.githubusercontent.com/assets/726447/12452490/68163cd6-bf6d-11e5-9b01-67b8db1ecd3f.png)
