### PR TITLE
Add advanced autocomplete for account names

### DIFF
--- a/lib/autocomplete-provider.coffee
+++ b/lib/autocomplete-provider.coffee
@@ -1,0 +1,54 @@
+execFile = require('child_process').execFile
+
+module.exports =
+  selector: '.source.ledger .string.account'
+  inclusionPriority: 2
+  suggestionPriority: 1
+
+  getSuggestions: ({editor, prefix, bufferPosition}) ->
+    accounts = @getAccountNames(editor)
+    prefix = @getPrefix(editor, bufferPosition)
+    prefix_low = prefix.toLowerCase()
+
+    filter = (acc, pref) ->
+      return acc.toLowerCase().indexOf(pref) >= 0
+
+    suggestions = ({text: a, replacementPrefix: prefix} for a in accounts when filter(a, prefix_low))
+    suggestions
+
+  getPrefix: (editor, bufferPosition) ->
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    line.trim()
+
+  getAccountNames: (editor) ->
+    if (editor.ledgerAccountsList?)
+      return editor.ledgerAccountsList
+    return @loadAccounts(editor)
+
+  dispose: ->
+    @disposable.dispose()
+
+  loadAccounts: (editor) ->
+    unless @disposable?
+      @disposable = editor.onDidSave (event) =>
+        editor.ledgerAccountsList = undefined
+    escapedPath = editor.getPath().split("'''").join("\\'\\'\\'")
+    pythonScript = """
+import ledger
+def print_recursive(accounts):
+  for a in accounts:
+    print a.fullname()
+    print_recursive(a.accounts())
+
+print_recursive(ledger.read_journal('''#{escapedPath}''').master.accounts())
+"""
+    ledgerBinary = atom.config.get 'language-ledger.ledgerBinary'
+    return new Promise (resolve, reject) ->
+      proc = execFile ledgerBinary, ["python"], {windowsHide: true}, (err, result, stderr) =>
+        if (err?)
+          console.log(err)
+          reject []
+        else
+          editor.ledgerAccountsList = result.split "\n"
+          resolve editor.ledgerAccountsList
+      proc.stdin.end(pythonScript)

--- a/lib/language-ledger.coffee
+++ b/lib/language-ledger.coffee
@@ -1,5 +1,6 @@
 {CompositeDisposable} = require 'atom'
 {Ledger} = require 'ledger-cli'
+autocompleteProvider = require './autocomplete-provider'
 
 bufferFilePath = -> atom.workspace.getActivePaneItem()?.buffer.file?.path
 
@@ -24,13 +25,14 @@ ledgerTransactions = (journalPath, callback) ->
     .once 'end', () -> callback(null, transactions)
 
 module.exports =
-  # Your config schema!
   config:
     ledgerBinary:
       title: 'Ledger binary'
       description: 'Full path to the Ledger binary'
       type: 'string'
       default: 'ledger'
+
+  getProvider: -> autocompleteProvider
 
   activate: (state) ->
     TransactionsView = require './transactions-view'

--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
   "name": "language-ledger",
   "main": "./lib/language-ledger",
-  "version": "0.3.5",
+  "version": "0.4.5",
   "description": "Ledger language support in Atom",
   "repository": "https://github.com/4ourbit/language-ledger",
   "license": "MIT",
   "engines": {
     "atom": ">=1.2.0"
+  },
+  "providedServices": {
+    "autocomplete.provider": {
+      "versions": {
+        "4.0.0": "getProvider"
+      }
+    }
   },
   "dependencies": {
     "javascript-state-machine": "^2.3.5",

--- a/settings/language-ledger.cson
+++ b/settings/language-ledger.cson
@@ -99,6 +99,7 @@
     symbols:
       Account:
         selector: '.string.account'
+        suggestionPriority: 2
 
 '.source.ledger .string.payee':
   autocomplete:


### PR DESCRIPTION
👋 this PR adds an additional autocomplete provider, which makes available all account names which are defined in this file. This includes (as was relevant to my use case) names defined by an `account` directive in an `include`d file.

Getting the list of available account names is done with ledger's built-in python, because `ledger accounts` (and information made available by `ledger-cli`) excludes accounts defined with `account` but not used.

This is done asynchronously, and memoized until the file is saved. One list is saved per `TextEditor` instance (i.e. per file). In my experience this operation is relatively fast (<100ms) and the returned list is quite small.

Some inspiration was taken from the way `be9/atom-ledger` handles this.